### PR TITLE
컴파일 및 런타임 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 	implementation "com.querydsl:querydsl-collections"
 
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+	// java.lang.NoClassDefFoundError (javax.annotation.Generated) 에러 대응 코드
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Hibernate ORM
+	implementation 'org.hibernate.orm:hibernate-core:6.0.0.Final'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [x] 버그 수정

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

CLOSE #24

## 반영 브랜치를 적어주세요.


branch : Feat/Matching-도메인-기초-설계

## 상세 내용을 적어주세요.

에러 메시지를 보면 **IncompatibleClassChangeError**가 발생했고, 그 이유는 org.springframework.orm.jpa.vendor.SpringHibernateJpaPersistenceProvider 클래스가 jakarta.persistence.spi.PersistenceProvider 인터페이스를 구현하지 않았다는 내.

즉, JPA와 관련된 버전 불일치가 문제라는 의미

### 원인
Spring Boot와 JPA 구현체(예: Hibernate) 사이의 버전 충돌로 인해 발생하는 문제로 보이는데, 주로 Jakarta EE로의 이전(이전에는 javax.persistence를 사용하던 패키지가 **jakarta.persistence**로 변경된 것) 때문에 발생하는 호환성 문제

### 해결
의존성을 jakarta.persistence 버전으로 맞추고, Spring Boot 및 Hibernate의 최신 버전을 사용해야 함