### PR TITLE
#71 [FEAT] Image S3에 다중이미지 업로드, 이미지 업로드, 다중 이미지 수정 기능 추가

### DIFF
--- a/src/main/java/com/sharespace/sharespace_server/global/exception/error/ImageException.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/exception/error/ImageException.java
@@ -10,7 +10,10 @@ import lombok.AllArgsConstructor;
 public enum ImageException implements CustomException {
 	IMAGE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "이미지를 업로드하는 중 오류가 발생했습니다."),
 	IMAGE_UPDATE_FAIL(HttpStatus.BAD_REQUEST, "이미지를 업로드하는 중 오류가 발생했습니다."),
-	IMAGE_DELETE_FAIL(HttpStatus.BAD_REQUEST, "이미지를 삭제하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+	IMAGE_DELETE_FAIL(HttpStatus.BAD_REQUEST, "이미지를 삭제하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
+	IMAGE_GET_FAIL(HttpStatus.BAD_REQUEST, "이미지를 불러오는 과정에서 오류가 발생하였습니다."),
+	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "허용되지 않은 파일 확장자입니다."),
+	IMAGE_REQUIRED_FIELDS_EMPTY(HttpStatus.BAD_REQUEST, "이미지가 누락되었습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/sharespace/sharespace_server/global/utils/S3ImageUpload.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/utils/S3ImageUpload.java
@@ -1,6 +1,7 @@
 package com.sharespace.sharespace_server.global.utils;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -13,37 +14,30 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
 public class S3ImageUpload {
 
-	private static AmazonS3 staticAmazonS3;
+	private AmazonS3 amazonS3;
+
+	public S3ImageUpload(AmazonS3 amazonS3) {
+		this.amazonS3 = amazonS3;
+	}
 
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucketName;
-
-	private static String staticBucketName;
-
-	public S3ImageUpload(AmazonS3 amazonS3) {
-		staticAmazonS3 = amazonS3;
-	}
-
-	@PostConstruct
-	public void init() {
-		staticBucketName = bucketName;
-	}
 
 	/**
 	 * <p>단일 이미지 파일을 S3 버킷에 업로드하는 메서드</p>
 	 *
 	 * <p>
-	 * 주어진 `MultipartFile`을 S3의 지정된 디렉토리에 업로드하며, 업로드된 파일의 URL을 반환합니다.
+	 * 주어진 `MultipartFile`을 S3의 지정된 디렉토리에 업로드하며, 업로드된 파일의 S3 경로를 반환합니다.
 	 * 파일은 UUID를 사용하여 고유한 이름으로 저장되며, S3에 Public 읽기 권한을 부여합니다.
 	 * 업로드 실패 시, `ImageException.IMAGE_UPLOAD_FAIL` 예외를 던집니다.
 	 * </p>
@@ -56,10 +50,10 @@ public class S3ImageUpload {
 	 *
 	 * <p>업로드 프로세스:
 	 * <pre>
-	 * 1. `UUID.randomUUID()`를 사용하여 고유한 파일명을 생성하고, 원본 파일명과 함께 저장 경로를 설정합니다.
+	 * 1. `UUID.randomUUID()`를 사용하여 고유한 파일명을 생성하고, 지정된 디렉토리와 결합하여 저장 경로를 설정합니다.
 	 * 2. `ObjectMetadata`를 사용하여 파일의 Content-Type과 Content-Length를 설정합니다.
 	 * 3. `putObject`를 통해 파일을 S3에 업로드하며, Public 읽기 권한을 부여합니다.
-	 * 4. 업로드 완료 후 업로드된 파일의 URL을 반환합니다.
+	 * 4. 업로드 완료 후 업로드된 파일의 S3 내 경로(파일명)를 반환합니다.
 	 * </pre>
 	 *
 	 * 예외 처리:
@@ -68,59 +62,163 @@ public class S3ImageUpload {
 	 *
 	 * @param multipartFile 업로드할 이미지 파일 (`MultipartFile` 타입)
 	 * @param dirName S3에 저장될 이미지 폴더 경로 (예: "profile", "images/uploads/")
-	 * @return 업로드된 파일의 S3 URL (예: "https://your-bucket.s3.amazonaws.com/profile/uuid_filename.jpg")
+	 * @return 업로드된 파일의 S3 경로 (예: "profile/uuid_filename.jpg")
+	 * @Author thereisname
 	 */
-	public static String uploadFile(MultipartFile multipartFile, String dirName) {
+	public String uploadFile(MultipartFile multipartFile, String dirName) {
+		// 파일 확잠자 가져오기
+		String extension = getFileExtension(multipartFile.getOriginalFilename());
+		// 파일 확장자 검증
+		validateFileExtension(extension);
 		// 파일명을 UUID로 고유하게 설정
-		String fileName = dirName + "/" + UUID.randomUUID() + "_" + multipartFile.getOriginalFilename();
+		String fileName = dirName + "/" + UUID.randomUUID() + "." + extension;
 
 		// 파일 메타데이터 설정
 		ObjectMetadata metadata = new ObjectMetadata();
 		metadata.setContentType(multipartFile.getContentType());
 		metadata.setContentLength(multipartFile.getSize());
 
+		// S3 Bucket에 업로드
 		try {
 			// S3에 파일 업로드
-			staticAmazonS3.putObject(new PutObjectRequest(staticBucketName, fileName, multipartFile.getInputStream(), metadata)
-				.withCannedAcl(CannedAccessControlList.PublicRead)); // Public 권한 부여
+			amazonS3.putObject(
+				new PutObjectRequest(bucketName, fileName, multipartFile.getInputStream(), metadata)
+					.withCannedAcl(CannedAccessControlList.PublicRead)); // Public 권한 부여
+			multipartFile.getInputStream().close();
 		} catch (IOException e) {
-			log.error("Image Upload error: " + e.getMessage());
+			log.error("Image Upload error: {}", e.getMessage());
 			throw new CustomRuntimeException(ImageException.IMAGE_UPLOAD_FAIL);
 		}
 
 		// 업로드된 파일의 URL 반환
-		return staticAmazonS3.getUrl(staticBucketName, fileName).toString();
+		return amazonS3.getUrl(bucketName, fileName).toString();
 	}
 
 	/**
 	 * <p>다중 이미지 업로드 메서드</p>
 	 *
-	 * <p>주어진 이미지 파일 리스트를 받아 지정된 S3 버킷의 특정 디렉토리에 업로드</p>
-	 * <p>업로드된 파일들의 URL은 콤마(",")로 구분된 문자열 반환</p>
+	 * <p>주어진 이미지 파일 리스트를 받아 지정된 S3 버킷의 특정 디렉토리에 업로드합니다.</p>
+	 * <p>업로드된 파일들의 S3 경로(파일명)를 콤마(",")로 구분한 문자열로 반환합니다.</p>
+	 *
+	 * <pre>{@code
+	 * // 예시 사용법 (이미지를 place/{userId} 폴더 내 저장)
+	 * String combinedImagePaths = uploadMultipleFiles(
+	 * 		placeRequest.getImageUrl(), "place/" + user.getId()
+	 * );
+	 * }</pre>
 	 *
 	 * <p>
 	 * 업로드 프로세스:
 	 * <pre>
 	 * 1. 주어진 `multipartFiles` 리스트에서 각 파일을 순차적으로 처리합니다.
 	 * 2. 각 파일은 S3에 지정된 `dirName` 경로를 포함하여 업로드됩니다.
-	 * 3. `uploadFile` 메서드를 통해 파일을 업로드하며, 해당 파일의 S3 URL을 반환받습니다.
-	 * 4. 모든 파일이 업로드되면 각 파일의 S3 URL을 콤마(",")로 구분하여 하나의 문자열로 반환합니다.
+	 * 3. `uploadFile` 메서드를 호출하여 파일을 업로드하며, 해당 파일의 S3 경로(파일명)를 반환받습니다.
+	 * 4. 모든 파일이 업로드되면 각 파일의 S3 경로(파일명)를 콤마(",")로 구분하여 하나의 문자열로 반환합니다.
 	 * </pre>
 	 * </p>
 	 *
-	 * @param multipartFiles 업로드할 이미지 파일들의 리스트. (비어 있거나 null인 경우 빈 문자열 반환)
+	 * 예외 처리:
+	 * - `uploadFile` 메서드에서 발생하는 예외가 상위로 전파됩니다.
+	 * - 업로드 중 오류가 발생할 경우, 해당 예외에 따라 적절한 오류 처리를 수행해야 합니다.
+	 *
+	 * @param multipartFiles 업로드할 이미지 파일들의 리스트. (비어 있거나 null인 경우 빈 문자열을 반환)
 	 * @param dirName S3에 저장될 이미지 폴더 경로 (예: "profile/", "places/3/")
-	 * @return 업로드된 이미지의 S3 URL을 콤마로 구분한 문자열로 반환 (예: "url1,url2,url3")
+	 * @return 업로드된 이미지의 S3 경로(파일명)를 콤마로 구분한 문자열로 반환 (예: "file1,file2,file3")
+	 * @Author thereisname
 	 */
-	public static String uploadMultipleFiles(List<MultipartFile> multipartFiles, String dirName) {
+	public List<String> uploadMultipleFiles(List<MultipartFile> multipartFiles, String dirName) {
 		List<String> uploadedUrls = new ArrayList<>();
 
+		multipartFiles.forEach(url -> uploadedUrls.add(uploadFile(url, dirName)));
+
 		for (MultipartFile file : multipartFiles) {
-			String fileUrl = uploadFile(file, dirName);
-			uploadedUrls.add(fileUrl);
+			String fileName = uploadFile(file, dirName);
+			uploadedUrls.add(fileName);
 		}
 
-		return String.join(",", uploadedUrls);
+		return uploadedUrls;
 	}
 
+	/**
+	 * <p>이미지 수정 메서드</p>
+	 *
+	 * <p>이 메서드는 기존 이미지의 일부를 삭제하고, 새로운 이미지를 업로드한 후
+	 * 최종적으로 업데이트된 이미지 URL 리스트를 반환합니다.</p>
+	 *
+	 * @param deleteImageUrls 삭제할 이미지의 URL 목록. (S3에서 삭제할 이미지 URL들)
+	 * @param newImageUrl 업로드할 새로운 이미지 파일들의 리스트. (MultipartFile 타입)
+	 * @param dirName S3에 저장할 디렉토리 이름. (예: "profile/", "places/")
+	 * @param existingImageUrl 기존에 저장된 이미지 URL. (삭제 후 유지될 이미지 URL)
+	 * @return 최종적으로 유지되거나 새로 추가된 이미지들의 URL 리스트.
+	 *         S3에서 삭제한 URL을 제거하고, 새로 업로드한 URL을 추가한 리스트를 반환.
+	 * @Author thereisname
+	 */
+	public List<String> updateImages(List<String> deleteImageUrls, List<MultipartFile> newImageUrl, String dirName, String existingImageUrl) {
+		// 기존 이미지 URL을 리스트에 추가
+		List<String> uploadedUrls = new ArrayList<>(List.of(existingImageUrl));
+
+		// S3에서 이미지 삭제
+		if (!deleteImageUrls.isEmpty()) {
+			deleteImageUrls.forEach(this::deleteImage);
+			// 삭제된 URL을 목록에서 제거
+			uploadedUrls.removeAll(deleteImageUrls);
+		}
+
+		// 새로운 이미지가 있으면 S3에 업로드
+		if (isRequestImages(newImageUrl)) {
+			// 새로운 이미지 파일을 S3에 업로드하고, URL을 리스트에 추가
+			List<String> url = uploadMultipleFiles(newImageUrl, dirName);
+			uploadedUrls.addAll(url);
+		}
+
+		// 최종적으로 남은 이미지 URL 리스트 반환
+		return uploadedUrls;
+	}
+
+	/**
+	 * 주어진 이미지 파일 리스트에서 비어있는 파일이 있는지 확인합니다.
+	 *
+	 * @param files 업로드할 이미지 파일 리스트 (MultipartFile 타입)
+	 *              파일 리스트에 포함된 각 파일이 비어있는지 여부를 검사합니다.
+	 *
+	 * @return 파일 리스트에 비어있는 파일이 하나도 없으면 true,
+	 *         비어있는 파일이 하나라도 있으면 false를 반환합니다.
+	 * @Author thereisname
+	 */
+	public boolean isRequestImages(List<MultipartFile> files) {
+		return files.stream().noneMatch(MultipartFile::isEmpty);
+	}
+
+	// task: 한개의 이미지 삭제
+	private void deleteImage(String fileUrl) {
+		try {
+			amazonS3.deleteObject(
+				bucketName, fileUrl.substring(fileUrl.indexOf(".com") + 5)
+			);
+		} catch (AmazonS3Exception e) {
+			log.error("Image Delete Error: {}", e.getMessage());
+			throw new CustomRuntimeException(ImageException.IMAGE_DELETE_FAIL);
+		}
+	}
+
+	// task: file 확장자 가져오기
+	private String getFileExtension(String fileName) {
+		// 파일 이름이 null이거나 확장자가 없는 경우 처리
+		if (fileName != null && fileName.contains(".")) {
+			// 마지막 점(.) 이후의 문자열을 확장자로 반환
+			return fileName.substring(fileName.lastIndexOf(".") + 1);
+		} else {
+			throw new IllegalArgumentException("Invalid file: no extension found.");
+		}
+	}
+
+	// task: file 확장자 검증
+	private void validateFileExtension(String extension) {
+		List<String> allowedExtensions = Arrays.asList("png", "jpeg", "jpg");
+
+		// 확장자가 허용된 리스트에 있는지 검사
+		if (!allowedExtensions.contains(extension.toLowerCase())) {
+			throw new CustomRuntimeException(ImageException.INVALID_FILE_EXTENSION);
+		}
+	}
 }

--- a/src/main/java/com/sharespace/sharespace_server/place/controller/PlaceController.java
+++ b/src/main/java/com/sharespace/sharespace_server/place/controller/PlaceController.java
@@ -54,7 +54,7 @@ public class PlaceController {
 
 	// task: 장소 수정
 	@PutMapping
-	public BaseResponse<String> updatePlace(@RequestBody PlaceUpdateRequest placeRequest) {
+	public BaseResponse<String> updatePlace(@ModelAttribute PlaceUpdateRequest placeRequest) {
 		return placeService.updatePlace(placeRequest);
 	}
 }

--- a/src/main/java/com/sharespace/sharespace_server/place/dto/PlaceDetailResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/place/dto/PlaceDetailResponse.java
@@ -1,5 +1,8 @@
 package com.sharespace.sharespace_server.place.dto;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.sharespace.sharespace_server.place.entity.Place;
 
 import lombok.AllArgsConstructor;
@@ -16,7 +19,7 @@ public class PlaceDetailResponse {
 	private String title;
 	private String category;
 	private Integer period;
-	private String imageUrl;
+	private List<String> imageUrl;
 	private String description;
 
 	// from 메서드 추가
@@ -26,7 +29,7 @@ public class PlaceDetailResponse {
 			.title(place.getTitle())
 			.category(place.getCategory().toString()) // 카테고리가 객체라면 toString() 등 적절한 변환 필요
 			.period(place.getPeriod())
-			.imageUrl(place.getImageUrl())
+			.imageUrl(Arrays.asList(place.getImageUrl().split(",")))
 			.description(place.getDescription())
 			.build();
 	}

--- a/src/main/java/com/sharespace/sharespace_server/place/dto/PlaceRequest.java
+++ b/src/main/java/com/sharespace/sharespace_server/place/dto/PlaceRequest.java
@@ -6,6 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.sharespace.sharespace_server.global.enums.Category;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -14,9 +15,13 @@ import lombok.Setter;
 @Getter
 @RequiredArgsConstructor
 public class PlaceRequest {
+	@NotNull(message = "Title을 입력해주세요")
 	private String title;
+	@NotNull(message = "Category를 선택해주세요")
 	private Category category;
+	@NotNull(message = "최대 보관 기간을 입력해주세요")
 	private Integer period;
+	@NotNull(message = "이미지를 선택해주세요")
 	private List<MultipartFile> imageUrl;
 	private String description;
 }

--- a/src/main/java/com/sharespace/sharespace_server/place/dto/PlaceUpdateRequest.java
+++ b/src/main/java/com/sharespace/sharespace_server/place/dto/PlaceUpdateRequest.java
@@ -1,7 +1,12 @@
 package com.sharespace.sharespace_server.place.dto;
 
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
 import com.sharespace.sharespace_server.global.enums.Category;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -10,10 +15,15 @@ import lombok.Setter;
 @Getter
 @RequiredArgsConstructor
 public class PlaceUpdateRequest {
+	@NotNull(message = "Title을 입력해주세요")
 	private String title;
+	@NotNull(message = "Category를 선택해주세요")
 	private Category category;
+	@NotNull(message = "최대 보관 기간을 입력해주세요")
 	private Integer period;
-	private String image_url;
-	private String description;
+	@NotNull(message = "위치 정보를 입력해주세요")
 	private String location;
+	private List<MultipartFile> newImageUrl;
+	private List<String> deleteImageUrl;
+	private String description;
 }

--- a/src/main/java/com/sharespace/sharespace_server/place/service/PlaceService.java
+++ b/src/main/java/com/sharespace/sharespace_server/place/service/PlaceService.java
@@ -1,23 +1,24 @@
 package com.sharespace.sharespace_server.place.service;
 
 import static com.sharespace.sharespace_server.global.utils.LocationTransform.*;
-import static com.sharespace.sharespace_server.global.utils.S3ImageUpload.*;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import com.sharespace.sharespace_server.global.enums.Category;
 import com.sharespace.sharespace_server.global.exception.CustomRuntimeException;
+import com.sharespace.sharespace_server.global.exception.error.ImageException;
 import com.sharespace.sharespace_server.global.exception.error.PlaceException;
 import com.sharespace.sharespace_server.global.exception.error.ProductException;
 import com.sharespace.sharespace_server.global.exception.error.UserException;
 import com.sharespace.sharespace_server.global.response.BaseResponse;
 import com.sharespace.sharespace_server.global.response.BaseResponseService;
 import com.sharespace.sharespace_server.global.utils.LocationTransform;
+import com.sharespace.sharespace_server.global.utils.S3ImageUpload;
 import com.sharespace.sharespace_server.place.dto.PlaceDetailResponse;
 import com.sharespace.sharespace_server.place.dto.PlaceRequest;
 import com.sharespace.sharespace_server.place.dto.PlaceUpdateRequest;
@@ -42,40 +43,7 @@ public class PlaceService {
 	private final PlaceRepository placeRepository;
 	private final ProductRepository productRepository;
 	private final LocationTransform locationTransform;
-
-	/**
-	 * 주어진 장소 정보를 게스트 사용자와 함께 PlacesResponse 객체로 매핑합니다.
-	 *
-	 * @param place 장소 정보
-	 * @param guest 게스트 사용자
-	 * @return 매핑된 PlacesResponse 객체
-	 * @throws CustomRuntimeException 호스트 사용자가 존재하지 않을 경우 발생
-	 */
-	private PlacesResponse mapToPlacesResponse(Place place, User guest) {
-		User host = userRepository.findById(place.getUser().getId())
-			.orElseThrow(() -> new CustomRuntimeException(UserException.MEMBER_NOT_FOUND));
-
-		Integer distance = calculateDistance(
-			guest.getLatitude(), guest.getLongitude(), host.getLatitude(), host.getLongitude()
-		);
-
-		// imageUrl 필드를 다중 이미지 배열로 변환
-		List<String> imageUrls = Arrays.asList(place.getImageUrl().split(","));
-
-		return PlacesResponse.builder()
-			.placeId(place.getId())
-			.title(place.getTitle())
-			.category(place.getCategory())
-			.imageUrls(imageUrls) // 다중 이미지 URL 배열 설정
-			.distance(distance)
-			.build();
-	}
-
-	// user 정보 찾기
-	private User findByUser(Long userId) {
-		return userRepository.findById(userId)
-			.orElseThrow(() -> new CustomRuntimeException(UserException.MEMBER_NOT_FOUND));
-	}
+	private final S3ImageUpload s3ImageUpload;
 
 	@Transactional
 	public BaseResponse<List<PlacesResponse>> getAllPlaces() {
@@ -106,7 +74,8 @@ public class PlaceService {
 
 	@Transactional
 	public BaseResponse<PlaceDetailResponse> getPlaceDetail(Long placeId) {
-		Place place = placeRepository.findById(placeId).orElseThrow(() -> new CustomRuntimeException(PlaceException.PLACE_NOT_FOUND));
+		Place place = placeRepository.findById(placeId)
+			.orElseThrow(() -> new CustomRuntimeException(PlaceException.PLACE_NOT_FOUND));
 
 		PlaceDetailResponse placeDetailResponse = PlaceDetailResponse.from(place);
 
@@ -115,13 +84,7 @@ public class PlaceService {
 
 	@Transactional
 	public BaseResponse<String> createPlace(PlaceRequest placeRequest) {
-		User user = findByUser(1L);
-
-		// request 항목 중 하나라도 빈 값이 들어온 경우 예외 처리
-		if(placeRequest.getTitle().isEmpty() || placeRequest.getPeriod() == null
-			|| placeRequest.getCategory() == null || placeRequest.getDescription().isEmpty()) {
-			throw new CustomRuntimeException(PlaceException.PLACE_REQUIRED_FIELDS_EMPTY);
-		}
+		User user = findByUser(5L);
 
 		// 이미 User Id의 값으로 장소가 만들어져 있는 경우 예외 처리
 		placeRepository.findByUserId(user.getId())
@@ -129,8 +92,13 @@ public class PlaceService {
 				throw new CustomRuntimeException(PlaceException.PLACE_ALREADY_EXISTS);
 			});
 
+		// 이미지 Request 검증
+		if (!s3ImageUpload.isRequestImages(placeRequest.getImageUrl())) {
+			throw new CustomRuntimeException(ImageException.IMAGE_REQUIRED_FIELDS_EMPTY);
+		};
+
 		// 다중 이미지 S3에 업로드
-		String combinedImageUrls = uploadMultipleFiles(placeRequest.getImageUrl(), "place/" +user.getId());
+		List<String> combinedImageUrls = s3ImageUpload.uploadMultipleFiles(placeRequest.getImageUrl(), "place/" +user.getId());
 
 		Place place = Place.builder()
 			.title(placeRequest.getTitle())
@@ -138,7 +106,7 @@ public class PlaceService {
 			.period(placeRequest.getPeriod())
 			.description(placeRequest.getDescription())
 			.category(placeRequest.getCategory())
-			.imageUrl(combinedImageUrls)
+			.imageUrl(combinedImageUrls.toString())
 			.build();
 
 		placeRepository.save(place);
@@ -148,33 +116,83 @@ public class PlaceService {
 
 	@Transactional
 	public BaseResponse<String> updatePlace(PlaceUpdateRequest placeRequest) {
-		// request 항목 중 하나라도 빈 값이 들어온 경우 예외 처리
-		if(placeRequest.getTitle().isEmpty() || placeRequest.getPeriod() == null
-			|| placeRequest.getCategory() == null || placeRequest.getDescription().isEmpty()
-			|| placeRequest.getLocation().isEmpty()) {
-			throw new CustomRuntimeException(PlaceException.PLACE_REQUIRED_FIELDS_EMPTY);
-		}
-
 		User user = findByUser(1L);
-
-		Map<String, Double> coordinates = locationTransform.getCoordinates(placeRequest.getLocation());
-
-		user.setLocation(placeRequest.getLocation());
-		user.setLatitude(coordinates.get("latitude"));
-		user.setLongitude(coordinates.get("longitude"));
 
 		Place place = placeRepository.findByUserId(user.getId())
 			.orElseThrow(() -> new CustomRuntimeException(PlaceException.PLACE_NOT_FOUND));
 
-		place.setTitle(placeRequest.getTitle());
-		place.setPeriod(placeRequest.getPeriod());
-		place.setCategory(placeRequest.getCategory());
-		place.setDescription(placeRequest.getDescription());
-		place.setImageUrl(placeRequest.getImage_url());
+		List<String> updateImages = s3ImageUpload.updateImages(
+			placeRequest.getDeleteImageUrl(), placeRequest.getNewImageUrl(),
+			"place/" + user.getId(), place.getImageUrl());
 
+		// 이미지 업데이트 처리
+		place.setImageUrl(String.join(",", updateImages));
+
+		// 사용자 위치 업데이트
+		updateUserLocation(user, placeRequest);
+		// 장소 필드 및 이미지 URL 업데이트
+		updatePlaceFields(place, placeRequest, updateImages);
+
+		// 변경 사항 저장
 		userRepository.save(user);
 		placeRepository.save(place);
 
 		return baseResponseService.getSuccessResponse("장소 수정 성공!");
+	}
+
+	// task: 장소 정보를 게스트, 호스트 거리를 포함하여 PlacesResponse 객체로 변환
+	private PlacesResponse mapToPlacesResponse(Place place, User guest) {
+		User host = findByUser(place.getUser().getId());
+
+		Integer distance = calculateDistance(
+			guest.getLatitude(), guest.getLongitude(), host.getLatitude(), host.getLongitude()
+		);
+
+		return PlacesResponse.builder()
+			.placeId(place.getId())
+			.title(place.getTitle())
+			.category(place.getCategory())
+			.imageUrls(List.of(place.getImageUrl().split(","))) // 다중 이미지 URL 배열 설정
+			.distance(distance)
+			.build();
+	}
+
+	// task: user 정보 찾기
+	private User findByUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new CustomRuntimeException(UserException.MEMBER_NOT_FOUND));
+	}
+
+	// task: 장소 위치 변경 로직
+	private void updateUserLocation(User user, PlaceUpdateRequest placeRequest) {
+		// 사용자의 위치가 변경되었는지 확인
+		if (!user.getLocation().equals(placeRequest.getLocation())) {
+			// 새로운 위치에 대한 좌표 변환
+			Map<String, Double> coordinates = locationTransform.getCoordinates(placeRequest.getLocation());
+			// 사용자 위치 정보 및 좌표 업데이트
+			user.setLocation(placeRequest.getLocation());
+			user.setLatitude(coordinates.get("latitude"));
+			user.setLongitude(coordinates.get("longitude"));
+		}
+	}
+
+	// task: 장소 필드 업데이트
+	private void updatePlaceFields(Place place, PlaceUpdateRequest placeRequest, List<String> updateImages) {
+		// 필드별로 null 허용하며, 값이 변경되었을 때만 업데이트
+		if (!Objects.equals(place.getTitle(), placeRequest.getTitle())) {
+			place.setTitle(placeRequest.getTitle());
+		}
+		if (!Objects.equals(place.getPeriod(), placeRequest.getPeriod())) {
+			place.setPeriod(placeRequest.getPeriod());
+		}
+		if (!Objects.equals(place.getCategory(), placeRequest.getCategory())) {
+			place.setCategory(placeRequest.getCategory());
+		}
+		if (!Objects.equals(place.getDescription(), placeRequest.getDescription())) {
+			place.setDescription(placeRequest.getDescription());
+		}
+
+		// 이미지 URL 업데이트
+		place.setImageUrl(String.join(",", updateImages));
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,7 +27,7 @@ cloud:
       secret-key: ${AWS_SECRET_KEY}
     stack.auto: false
     s3:
-      bucket: sharespace-images-bucket
+      bucket: ${BUCKET_NAME}
     region:
       static: ${AWS_REGION}
     stack:


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [x] 기타 작업

## 반영 브랜치를 적어주세요.

branch : Feat/71-Image-Upload-Download

## 상세 내용을 적어주세요.
- S3 Image Upload 추가
- S3 Image 수정 추가
    - S3에서는 이미지를 **수정하는 메서드를 제공하지 않음**
    - 따라서 Image 수정은 기존에 업로드 된 이미지 중에서 삭제할 이미지를 **삭제 후**, 새로 추가된 **이미지를 업로드** 하는 방식 적용
    - 이미지 수정이 포함된 Reqeust에는 삭제할 이미지 url(List<String> 타입)과 새로 업로드 해야 하는 이미지 (List<MultipartFile> 타입) 으로 response를 변경함
- 해당 이미지 업로드, 수정 항목을 Place 도메인에 적용
- 이미지 파일이 들어오는 Controller에 @RequestBody가 아닌 **@ ModelAttribute를 사용해야** 적용됨.
- request 이미지 파일은 **MultipartFile 타입**으로 전달 받으며, 다중 이미지의 경우 **List<MultipartFile>의 형태**로 request 받음
- 한글 깨짐을 방지와 파일 이믈 중복을 방지하기 위해 파일이름을 새롭게 생성하여 저장함