### PR TITLE
Notification, Matching 계층에 RequestParser 도입 및 주석 추가

### DIFF
--- a/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
@@ -1,5 +1,7 @@
 package com.sharespace.sharespace_server.matching.controller;
 
+import static com.sharespace.sharespace_server.global.utils.RequestParser.*;
+
 import com.sharespace.sharespace_server.matching.dto.request.MatchingGuestConfirmStorageRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingHostAcceptRequestRequest;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,8 +35,8 @@ public class MatchingController {
 	private final MatchingService matchingService;
 
 	@GetMapping()
-	public BaseResponse<List<MatchingShowAllResponse>> showAll() {
-		Long userId = 2L;
+	public BaseResponse<List<MatchingShowAllResponse>> showAll(HttpServletRequest request) {
+		Long userId = extractUserId(request);
 		return matchingService.showAll(userId);
 	}
 
@@ -50,9 +52,10 @@ public class MatchingController {
 
 	// STORED -> COMPLETED
 	@PatchMapping("/completeStorage")
-	public BaseResponse<Void> completeStorage(@Valid @RequestBody MatchingCompleteStorageRequest request) {
+	public BaseResponse<Void> completeStorage(@Valid @RequestBody MatchingCompleteStorageRequest request, HttpServletRequest servletRequest) {
 		Long matchingId = request.getMatchingId();
-		return matchingService.completeStorage(matchingId);
+		Long userId = extractUserId(servletRequest);
+		return matchingService.completeStorage(matchingId, userId);
 	}
 
 	@GetMapping("/requestDetail")
@@ -76,9 +79,9 @@ public class MatchingController {
 
 	// 보관 대기중일 때, Host와 Guest는 '요청 취소'를 할 수 있다.
 	@PostMapping("/cancelRequest")
-	public BaseResponse<Void> cancelRequest(@RequestParam("matchingId") Long matchingId/*, HttpServletRequest request*/) {
-		//Long userId = RequestParser.extractUserId(request);
-		return matchingService.cancelRequest(matchingId);
+	public BaseResponse<Void> cancelRequest(@RequestParam("matchingId") Long matchingId, HttpServletRequest request) {
+		Long userId = extractUserId(request);
+		return matchingService.cancelRequest(matchingId, userId);
 	}
 
 	@PostMapping("/uploadImage/host")

--- a/src/main/java/com/sharespace/sharespace_server/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/repository/MatchingRepository.java
@@ -31,6 +31,12 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 		+ "where p.user.id = :userId")
 	List<Matching> findMatchingWithProductByUserId(Long userId);
 
+	@Query("SELECT m "
+		+ "from Matching m "
+		+ "JOIN FETCH m.place p "
+		+ "where p.user.id = :userId")
+	List<Matching> findMatchingWithPlaceByUserId(Long userId);
+
 
 	// Matching을 조회할 때 Product까지만 가져오는 메서드
 	@Query("SELECT m FROM Matching m JOIN FETCH m.product")

--- a/src/main/java/com/sharespace/sharespace_server/notification/controller/NotificationController.java
+++ b/src/main/java/com/sharespace/sharespace_server/notification/controller/NotificationController.java
@@ -1,7 +1,10 @@
 package com.sharespace.sharespace_server.notification.controller;
 
 
+import static com.sharespace.sharespace_server.global.utils.RequestParser.*;
+
 import com.sharespace.sharespace_server.global.response.BaseResponse;
+import com.sharespace.sharespace_server.global.utils.RequestParser;
 import com.sharespace.sharespace_server.notification.dto.response.NotificationAllResponse;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -9,6 +12,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.sharespace.sharespace_server.notification.service.NotificationService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -26,8 +30,8 @@ public class NotificationController {
 	}
 
 	@GetMapping()
-	public BaseResponse<List<NotificationAllResponse>> getNotifications() {
-		Long userId = 1L;
+	public BaseResponse<List<NotificationAllResponse>> getNotifications(HttpServletRequest request) {
+		Long userId = extractUserId(request);
 		return notificationService.getNotifications(userId);
 	}
 

--- a/src/main/java/com/sharespace/sharespace_server/notification/service/NotificationService.java
+++ b/src/main/java/com/sharespace/sharespace_server/notification/service/NotificationService.java
@@ -35,6 +35,12 @@ public class NotificationService {
 	private final UserRepository userRepository;
 	private final NotificationRepository notificationRepository;
 	private final BaseResponseService baseResponseService;
+
+	/**
+	 * SSE 구독 요청 처리
+	 * @param userId 구독할 유저 ID
+	 * @return SseEmitter 객체를 반환해서 SSE 연결
+	 */
 	public SseEmitter subscribe(Long userId) {
 		SseEmitter emitter = new SseEmitter(30000000L);
 		sseEmitters.put(userId, emitter);
@@ -53,6 +59,11 @@ public class NotificationService {
 		return emitter;
 	}
 
+	/**
+	 * 유저에게 알림을 보내는 메서드
+	 * @param userId 알림을 받을 유저 ID
+	 * @param message 알림 메시지 내용
+	 */
 	@Transactional
 	public void sendNotification(Long userId, String message)  {
 		User user = userRepository.findById(userId)
@@ -76,6 +87,11 @@ public class NotificationService {
 		}
 	}
 
+	/**
+	 * 유저의 모든 알림을 가져오는 메서드
+	 * @param userId 알림을 조회할 유저 ID
+	 * @return 알림 리스트와 함께 성공 응답을 반환
+	 */
 	public BaseResponse<List<NotificationAllResponse>> getNotifications(Long userId) {
 		User user = userRepository.findById(userId).
 		orElseThrow(() -> new CustomRuntimeException(UserException.MEMBER_NOT_FOUND));
@@ -99,6 +115,11 @@ public class NotificationService {
 		return baseResponseService.getSuccessResponse(response);
 	}
 
+	/**
+	 * 알림을 삭제하는 메서드
+	 * @param notificationId 삭제할 알림 ID
+	 * @return 삭제 후 성공 응답 반환
+	 */
 	public BaseResponse<Void> deleteNotifcation(Long notificationId) {
 		notificationRepository.findById(notificationId)
 			.orElseThrow(() -> new CustomRuntimeException(NotificationException.NOTIFCATION_NOT_FOUND));

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true             # SQL 쿼리 로그 출력
+    show-sql: false             # SQL 쿼리 로그 출력
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect # MySQLDialect 사용


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 기타 작업

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

#108 

## 반영 브랜치를 적어주세요.

branch : `Chore/108-FE와-API-연결`

## 상세 내용을 적어주세요.
- `application.dev`의 `show-sql` 옵션을 `false`로 변경
- `Notification`과 `Matching`의 컨트롤러 계층에 `RequestParser` 도입 후 `HttpServletRequest`에 `userId`가 담겨오는 동작을 Parsing하여 가져올 수 있도록 처리