### PR TITLE
유저 로그인 상태 확인 API 추가 및 Matching 관련 버그 수정

### DIFF
--- a/src/main/java/com/sharespace/sharespace_server/global/exception/error/MatchingException.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/exception/error/MatchingException.java
@@ -17,6 +17,7 @@ public enum MatchingException implements CustomException {
 	INCORRECT_STATUS_CONFIRM_REQUEST_GUEST(HttpStatus.BAD_REQUEST, "Guest가 물품 보관을 수락하려면 Status가 '보관 대기중(Pending)' 이어야합니다."),
 	INVALID_PRODUCT_PERIOD(HttpStatus.BAD_REQUEST, "Product의 보관 기간은 Place보다 클 수 없습니다."),
 	REQUEST_CANCELLATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "상태가 보관 대기중(Pending)이 아니어서 보관 요청 취소를 할 수 없습니다."),
+	ALREADY_REQUESTED_PRODUCT_TO_SAME_PLACE(HttpStatus.BAD_REQUEST, "이미 해당 장소에 보관 요청을 하셨습니다"),
 	ALREADY_EXISTED_MATCHING(HttpStatus.BAD_REQUEST, "이미 존재하는 매칭입니다.");
 
 	private final HttpStatus status;

--- a/src/main/java/com/sharespace/sharespace_server/global/exception/error/ProductException.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/exception/error/ProductException.java
@@ -9,7 +9,8 @@ import lombok.AllArgsConstructor;
 // task: 임시 enum class. 추후 삭제 예정.
 @AllArgsConstructor
 public enum ProductException implements CustomException {
-    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 물품입니다.");
+    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 물품입니다."),
+    PRODUCT_NOT_MATCHED_TO_USER(HttpStatus.BAD_REQUEST, "해당 물품은 해당 사용자의 것이 아닙니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sharespace/sharespace_server/global/exception/error/UserException.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/exception/error/UserException.java
@@ -17,7 +17,9 @@ public enum UserException implements CustomException {
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호 양식을 지켜주세요."),
     PASSWORD_VALIDATE_FAIL(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인란에 기입된 값이 다릅니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
-    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다. 잠시 후 다시 시도해 주세요.");
+    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다. 잠시 후 다시 시도해 주세요."),
+    NOT_LOGGED_IN_USER(HttpStatus.UNAUTHORIZED, "로그인한 사용자가 아닙니다"),
+    NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 기능을 사용하기에 허용되지 않은 역할의 사용자입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sharespace/sharespace_server/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/filter/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
 
-    private final String[] whiteListUris = new String[] {"/login", "/user/login", "user/register"};
+    private final String[] whiteListUris = new String[] {"/login", "/user/login", "/user/register", "/user/checkLogin"};
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/com/sharespace/sharespace_server/global/utils/RequestParser.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/utils/RequestParser.java
@@ -1,5 +1,7 @@
 package com.sharespace.sharespace_server.global.utils;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -30,5 +32,10 @@ public class RequestParser {
 
         String userId = String.valueOf(claims.get("userId"));
         return Long.valueOf(userId);
+    }
+    public static String getCurrentUserRole() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String roles = authentication.getAuthorities().toString();
+        return roles.replace("[", "").replace("]","");
     }
 }

--- a/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
@@ -2,6 +2,8 @@ package com.sharespace.sharespace_server.matching.controller;
 
 import static com.sharespace.sharespace_server.global.utils.RequestParser.*;
 
+import com.sharespace.sharespace_server.global.exception.CustomRuntimeException;
+import com.sharespace.sharespace_server.global.exception.error.UserException;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingGuestConfirmStorageRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingHostAcceptRequestRequest;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,8 +43,14 @@ public class MatchingController {
 	}
 
 	@PostMapping("/keep")
-	public BaseResponse<Void> keep(@Valid @RequestBody MatchingKeepRequest request) {
-		return matchingService.keep(request);
+	public BaseResponse<Void> keep(@Valid @RequestBody MatchingKeepRequest matchingRequest, HttpServletRequest servletRequest) {
+		String currentUserRole = getCurrentUserRole();
+		// TODO : Spring AOP 사용하여 권한 관련 로직 중앙화하기
+		if (!currentUserRole.equals("ROLE_GUEST")) {
+			throw new CustomRuntimeException(UserException.NOT_AUTHORIZED);
+		}
+		Long userId = extractUserId(servletRequest);
+		return matchingService.keep(matchingRequest, userId);
 	}
 
 	@GetMapping("/keepDetail")

--- a/src/main/java/com/sharespace/sharespace_server/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/repository/MatchingRepository.java
@@ -49,4 +49,7 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 	// status가 특정 값이고, startDate + confirmDays가 오늘 날짜(today) 이전 또는 같은 Matching 엔티티들을 조회
 	@Query("SELECT m FROM Matching m WHERE m.status = :status AND m.startDate + :confirmDays <= :today")
 	List<Matching> findEligibleForNotification(Status status, int confirmDays, LocalDateTime today);
+
+	Optional<Matching> findMatchingByProductIdAndPlaceId(Long productId, Long placeId);
+
 }

--- a/src/main/java/com/sharespace/sharespace_server/product/entity/Product.java
+++ b/src/main/java/com/sharespace/sharespace_server/product/entity/Product.java
@@ -3,6 +3,7 @@ package com.sharespace.sharespace_server.product.entity;
 import com.sharespace.sharespace_server.global.enums.Category;
 import com.sharespace.sharespace_server.global.exception.CustomRuntimeException;
 import com.sharespace.sharespace_server.global.exception.error.MatchingException;
+import com.sharespace.sharespace_server.global.exception.error.ProductException;
 import com.sharespace.sharespace_server.place.entity.Place;
 import com.sharespace.sharespace_server.user.entity.User;
 import jakarta.persistence.*;
@@ -68,4 +69,13 @@ public class Product {
             throw new CustomRuntimeException(MatchingException.INVALID_PRODUCT_PERIOD);
         }
     }
+
+    // 사용자는 보관 요청을 보낼 때 product가 자신의 것이 맞는지 확인하는 검증을 해야함
+
+    public void validateProductOwnershipForUser(User user) {
+        if (!this.getUser().equals(user)) {
+            throw new CustomRuntimeException(ProductException.PRODUCT_NOT_MATCHED_TO_USER);
+        }
+    }
+
 }

--- a/src/main/java/com/sharespace/sharespace_server/user/controller/UserController.java
+++ b/src/main/java/com/sharespace/sharespace_server/user/controller/UserController.java
@@ -56,4 +56,9 @@ public class UserController {
         return userService.logout(accessToken, refreshToken, response, userId);
     }
 
+    @GetMapping("/checkLogin")
+    public BaseResponse<Void> checkLogin() {
+        return userService.checkLogin();
+    }
+
 }

--- a/src/main/java/com/sharespace/sharespace_server/user/service/UserService.java
+++ b/src/main/java/com/sharespace/sharespace_server/user/service/UserService.java
@@ -25,6 +25,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -312,4 +313,11 @@ public class UserService {
         response.addCookie(cookie);
     }
 
+    public BaseResponse<Void> checkLogin() {
+        if (SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+            .anyMatch(grantedAuthority -> "ROLE_ANONYMOUS".equals(grantedAuthority.getAuthority()))) {
+            throw new CustomRuntimeException(UserException.NOT_LOGGED_IN_USER);
+        }
+        return baseResponseService.getSuccessResponse();
+    }
 }


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 작업

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

#108 

## 반영 브랜치를 적어주세요.

branch : `Chore/108-FE와-API-연결`

## 상세 내용을 적어주세요.
- 유저 로그인 상태 요청하는 API 추가 (`/user/checkLogin/`), 커밋 제목은 잘못 올라간 겁니다.
- 무한 매칭 (`/matching/keep`)이 가능하던 버그 수정
- `Product` 엔티티 클래스 내 `User`과의 유효성 검증 추가, 이는 `keep()` 메서드 내에서 사용
- `RequestParser` 클래스에 `SecurityContextHolder`에 등록된 사용자의 권한 정보를 받아오는 메서드 추가
  - 이는 추후 도입할 **Spring AOP와 Custom Annotation을 통한 권한 관리 중앙화**에 사용될 예정이나, 수정 및 삭제될 수 있음