### PR TITLE
물품 보관 요청 및 물품 등록 API 수정

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -76,12 +76,12 @@ CREATE TABLE notification (
 CREATE TABLE matching (
     id BIGINT NOT NULL AUTO_INCREMENT,
     product_id BIGINT NOT NULL,
-    place_id BIGINT NOT NULL,
+    place_id BIGINT NULL,
     image TEXT NULL COMMENT '요청을 수락했을 경우 매칭 테이블에 저장됨.',
     status ENUM('UNASSIGNED', 'REQUESTED', 'REJECTED', 'PENDING', 'STORED', 'COMPLETED') NOT NULL,
     host_completed BOOLEAN NOT NULL DEFAULT 0,
     guest_completed BOOLEAN NOT NULL DEFAULT 0,
-    distance INT NOT NULL COMMENT 'm 단위로 저장',
+    distance INT NULL COMMENT 'm 단위로 저장',
     start_date DATETIME NULL,
     expiry_date DATETIME NULL,
     PRIMARY KEY (id),
@@ -99,5 +99,5 @@ CREATE TABLE contact (
 
 INSERT INTO user (nick_name, email, image, role, password, location, latitude, longitude, email_validated)
 VALUES
-    ('호스트민우갓', 'hostminwoo@example.com', 'temporary image url', 'ROLE_HOST', '1234', '서울', 200, 100, 1),
-    ('게스트민우갓', 'guestminwoo@example.com', 'temporary image url', 'ROLE_GUEST', '1234', '경기', 100, 200, 1);
+    ('호스트민우갓', 'hostminwoo@example.com', 'temporary image url', 'ROLE_HOST', '$2b$12$qZMgj4TG2KqU2ulwGnMD8.0eYstepNGJRva/GEheQHOYNbdS5hIhi', '서울', 200, 100, 1),
+    ('게스트민우갓', 'guestminwoo@example.com', 'temporary image url', 'ROLE_GUEST', '$2b$12$qZMgj4TG2KqU2ulwGnMD8.0eYstepNGJRva/GEheQHOYNbdS5hIhi', '경기', 100, 200, 1);

--- a/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
@@ -10,7 +10,9 @@ import com.sharespace.sharespace_server.matching.dto.request.MatchingHostAcceptR
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.sharespace.sharespace_server.global.response.BaseResponse;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingCompleteStorageRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingKeepRequest;
+import com.sharespace.sharespace_server.matching.dto.request.MatchingUpdateRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingUploadImageRequest;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowAllResponse;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowKeepDetailResponse;
@@ -50,7 +53,7 @@ public class MatchingController {
 		}
 	}
 
-	@PostMapping("/keep")
+	@PutMapping("/keep")
 	public BaseResponse<Void> keep(@Valid @RequestBody MatchingKeepRequest matchingRequest, HttpServletRequest servletRequest) {
 		String currentUserRole = getCurrentUserRole();
 		// TODO : Spring AOP 사용하여 권한 관련 로직 중앙화하기
@@ -103,5 +106,15 @@ public class MatchingController {
 	public BaseResponse<Void> uploadImage(@Valid @ModelAttribute MatchingUploadImageRequest request) {
 		return matchingService.uploadImage(request);
 	}
+
+	@PatchMapping("/matching/{matchingId}")
+	public BaseResponse<Void> updateMatching(@PathVariable Long matchingId,
+		@RequestBody MatchingUpdateRequest matchingUpdateRequest,
+		HttpServletRequest request
+		) {
+		Long userId = extractUserId(request);
+		return matchingService.updateMatchingWithPlace(matchingId, matchingUpdateRequest, userId);
+	}
+
 }
 

--- a/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
@@ -107,7 +107,7 @@ public class MatchingController {
 		return matchingService.uploadImage(request);
 	}
 
-	@PatchMapping("/matching/{matchingId}")
+	@PatchMapping("/{matchingId}")
 	public BaseResponse<Void> updateMatching(@PathVariable Long matchingId,
 		@RequestBody MatchingUpdateRequest matchingUpdateRequest,
 		HttpServletRequest request

--- a/src/main/java/com/sharespace/sharespace_server/matching/dto/MatchingAssembler.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/dto/MatchingAssembler.java
@@ -21,24 +21,13 @@ public class MatchingAssembler {
 	public MatchingShowAllResponse toMatchingShowAllResponse(Matching matching) {
 		Product product = matching.getProduct();
 		List<String> imageUrls = List.of(matching.getProduct().getImageUrl().split(","));
-		if (!product.getIsPlaced()) {
-			return MatchingShowAllResponse.builder()
-				.matchingId(null)
-				.title(product.getTitle())
-				.category(product.getCategory())
-				.imageUrl(imageUrls)
-				.status(UNASSIGNED)
-				.distance(null)
-				.build();
-		} else {
-			return MatchingShowAllResponse.builder()
-				.matchingId(matching.getId())
-				.title(product.getTitle())
-				.category(product.getCategory())
-				.imageUrl(imageUrls)
-				.status(matching.getStatus())
-				.distance(matching.getDistance())
-				.build();
-		}
+		return MatchingShowAllResponse.builder()
+			.matchingId(matching.getId())
+			.title(product.getTitle())
+			.category(product.getCategory())
+			.imageUrl(imageUrls)
+			.status(matching.getStatus())
+			.distance(matching.getDistance())
+			.build();
 	}
 }

--- a/src/main/java/com/sharespace/sharespace_server/matching/dto/request/MatchingUpdateRequest.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/dto/request/MatchingUpdateRequest.java
@@ -2,15 +2,9 @@ package com.sharespace.sharespace_server.matching.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
-public class MatchingKeepRequest {
-	@NotNull
-	private Long matchingId;
-	@NotNull
-	private Long productId;
+public class MatchingUpdateRequest {
 	@NotNull
 	private Long placeId;
 }

--- a/src/main/java/com/sharespace/sharespace_server/product/controller/ProductController.java
+++ b/src/main/java/com/sharespace/sharespace_server/product/controller/ProductController.java
@@ -1,10 +1,11 @@
 package com.sharespace.sharespace_server.product.controller;
 
 import com.sharespace.sharespace_server.global.response.BaseResponse;
+import com.sharespace.sharespace_server.global.utils.RequestParser;
 import com.sharespace.sharespace_server.product.dto.ProductRegisterRequest;
 import com.sharespace.sharespace_server.product.dto.ProductRegisterResponse;
 import com.sharespace.sharespace_server.product.service.ProductService;
-//import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -21,10 +22,8 @@ public class ProductController {
     private final ProductService productService;
 
     @PostMapping("/register")
-    public BaseResponse<ProductRegisterResponse> register(@Valid @ModelAttribute ProductRegisterRequest request) {
-//            , HttpServletRequest httpRequest) {
-//        Long userId = extractUserId(httpRequest);
-        Long userId = 1L;
+    public BaseResponse<ProductRegisterResponse> register(@Valid @ModelAttribute ProductRegisterRequest request, HttpServletRequest httpRequest) {
+        Long userId = RequestParser.extractUserId(httpRequest);
         return productService.register(request, userId);
     }
 }

--- a/src/main/java/com/sharespace/sharespace_server/product/dto/ProductRegisterResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/product/dto/ProductRegisterResponse.java
@@ -1,12 +1,16 @@
 package com.sharespace.sharespace_server.product.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@Builder
 public class ProductRegisterResponse {
 	private Long productId;
+	// 2024-10-27 matchingId 추가
+	private Long matchingId;
 }


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [x] 기타 작업

## 해결한 이슈의 번호를 적어주세요.

close #108 

## 반영 브랜치를 적어주세요.

branch : `Chore/108-FE와-API-연결`

## 상세 내용을 적어주세요.
- place_id, distance에 null 허용
- 초기 유저 데이터 삽입시 Encoding된 비밀번호 사용하도록 변경
- **신규 API 추가**
  - 미배정인 물품을 보관 요청할 때 사용되는 API 추가 (`/matching/{matchingId}`
- **기존 보관 요청 API 변경**
  - **HTTP Method 변경**
    - Post -> Put, 기존에는 Matching 데이터를 생성하는 방식이었다면 Update하는 방식으로 변경했으므로
- **`MatchingAssembler.java` 변경**
  - 기존에는 product의 `is_placed` 컬럼의 값에 따라 response를 다르게 내주었다면, 이제는 `Matching`에서 일괄로 관리하므로 응답을 일원화
- **`Matching.java` 변경**
  - 기존의 `keep()` 메서드에서 `Matching` 엔티티를 생성하기 위해 만들었던 `create` 메서드 삭제
  - 장소를 선택했을 때, 장소를 선택하지 않았을 때 사용되는 각각의 메서드 `createNotSelectedPlace()`, `createSelectedPlace()` 추가
- **`MatchingKeepRequest.java` 변경**
  -  `matchingId`까지 Request로 받게끔 추가
- **`ProductController.java`** :
  - `userId`가 `1L`로 하드코딩되어있던 것을 `RequestParser`를 사용하도록 변경
- **`ProductService.java` 및 `ProductRegisterResponse.java` :**
  - `Product` 등록시 `Matching` 테이블에도 레코드가 생성되게끔 변경
  - Response에 `matchingId`까지 넘겨주도록 변경

신규 : 미배정 물품 보관 요청 API 엔드포인트 잘못되어있던 것 수정