### PR TITLE
유저 회원가입 개선 및 Matching API 업데이트, 자잘한 코드 수정

### DIFF
--- a/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/controller/MatchingController.java
@@ -23,6 +23,7 @@ import com.sharespace.sharespace_server.matching.dto.request.MatchingCompleteSto
 import com.sharespace.sharespace_server.matching.dto.request.MatchingKeepRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingUpdateRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingUploadImageRequest;
+import com.sharespace.sharespace_server.matching.dto.response.MatchingShowAllProductWithRoleResponse;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowAllResponse;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowKeepDetailResponse;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowRequestDetailResponse;
@@ -41,7 +42,7 @@ public class MatchingController {
 	private final MatchingService matchingService;
 
 	@GetMapping
-	public BaseResponse<List<MatchingShowAllResponse>> showList(
+	public BaseResponse<MatchingShowAllProductWithRoleResponse> showList(
 		@RequestParam(value = "status", required = false) Status status,
 		HttpServletRequest request) {
 		Long userId = extractUserId(request);
@@ -115,6 +116,16 @@ public class MatchingController {
 		Long userId = extractUserId(request);
 		return matchingService.updateMatchingWithPlace(matchingId, matchingUpdateRequest, userId);
 	}
+
+	@GetMapping("/by-place")
+	public BaseResponse<List<MatchingShowAllResponse>> getProductsByPlace(
+		@RequestParam Long placeId,
+		HttpServletRequest request
+	) {
+		Long userId = extractUserId(request);
+		return matchingService.getProductsByPlace(placeId, userId);
+	}
+
 
 }
 

--- a/src/main/java/com/sharespace/sharespace_server/matching/dto/MatchingAssembler.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/dto/MatchingAssembler.java
@@ -1,10 +1,8 @@
 package com.sharespace.sharespace_server.matching.dto;
 
-import static com.sharespace.sharespace_server.global.enums.Status.*;
 
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowAllResponse;
 import com.sharespace.sharespace_server.matching.entity.Matching;
-import com.sharespace.sharespace_server.matching.repository.MatchingRepository;
 import com.sharespace.sharespace_server.product.entity.Product;
 import java.util.List;
 
@@ -16,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 @Component
 public class MatchingAssembler {
 
-	private final MatchingRepository matchingRepository;
 
 	public MatchingShowAllResponse toMatchingShowAllResponse(Matching matching) {
 		Product product = matching.getProduct();

--- a/src/main/java/com/sharespace/sharespace_server/matching/dto/response/MatchingShowAllProductWithRoleResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/dto/response/MatchingShowAllProductWithRoleResponse.java
@@ -1,0 +1,13 @@
+package com.sharespace.sharespace_server.matching.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MatchingShowAllProductWithRoleResponse {
+	private String role;
+	private List<MatchingShowAllResponse> products;
+}

--- a/src/main/java/com/sharespace/sharespace_server/matching/dto/response/MatchingShowAllResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/dto/response/MatchingShowAllResponse.java
@@ -16,4 +16,5 @@ public class MatchingShowAllResponse {
 	private List<String> imageUrl; // product 이미지
 	private Status status;
 	private Integer distance;
+	private String role;
 }

--- a/src/main/java/com/sharespace/sharespace_server/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/repository/MatchingRepository.java
@@ -61,9 +61,18 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 	List<Matching> findAllWithPlace();
 
 	// status가 특정 값이고, startDate + confirmDays가 오늘 날짜(today) 이전 또는 같은 Matching 엔티티들을 조회
-	@Query("SELECT m FROM Matching m WHERE m.status = :status AND m.startDate + :confirmDays <= :today")
+	@Query("SELECT m FROM Matching m "
+		+ "WHERE m.status = :status AND "
+		+ "m.startDate + :confirmDays <= :today")
 	List<Matching> findEligibleForNotification(Status status, int confirmDays, LocalDateTime today);
 
 	Optional<Matching> findMatchingByProductIdAndPlaceId(Long productId, Long placeId);
+
+	@Query("SELECT m FROM Matching m "
+		+ "JOIN FETCH m.product p "
+		+ "WHERE (m.status = 'REJECTED' OR m.status = 'UNASSIGNED') "
+		+ "AND p.user.id = :userId")
+	List<Matching> findMatchingsWithProductByStatus(Long userId);
+
 
 }

--- a/src/main/java/com/sharespace/sharespace_server/matching/service/MatchingService.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/service/MatchingService.java
@@ -22,6 +22,7 @@ import com.sharespace.sharespace_server.global.response.BaseResponseService;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingKeepRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingUpdateRequest;
 import com.sharespace.sharespace_server.matching.dto.request.MatchingUploadImageRequest;
+import com.sharespace.sharespace_server.matching.dto.response.MatchingShowAllProductWithRoleResponse;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowAllResponse;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowKeepDetailResponse;
 import com.sharespace.sharespace_server.matching.dto.response.MatchingShowRequestDetailResponse;
@@ -70,22 +71,30 @@ public class MatchingService {
 	 * @return BaseResponse<List<MatchingShowAllResponse>> - 사용자의 매칭 정보를 담은 응답 객체
 	 */
 
-	public BaseResponse<List<MatchingShowAllResponse>> showAll(Long userId) {
+	public BaseResponse<MatchingShowAllProductWithRoleResponse> showAll(Long userId) {
 		User user = findUser(userId);
 		List<Matching> matchings = getMatchingsByRole(user);
 		List<MatchingShowAllResponse> responses = matchings.stream()
 			.map(matchingAssembler::toMatchingShowAllResponse)
 			.collect(Collectors.toList());
-		return baseResponseService.getSuccessResponse(responses);
+		return baseResponseService.getSuccessResponse(
+			MatchingShowAllProductWithRoleResponse.builder()
+				.role(user.getRole().getValue())
+				.products(responses)
+				.build());
 	}
 
-	public BaseResponse<List<MatchingShowAllResponse>> showFilteredList(Status status, Long userId) {
+	public BaseResponse<MatchingShowAllProductWithRoleResponse> showFilteredList(Status status, Long userId) {
 		User user = findUser(userId);
 		List<Matching> matchings = getFilteredMatchingsByRole(user, status);
 		List<MatchingShowAllResponse> responses = matchings.stream()
 			.map(matchingAssembler::toMatchingShowAllResponse)
 			.collect(Collectors.toList());
-		return baseResponseService.getSuccessResponse(responses);
+		return baseResponseService.getSuccessResponse(
+			MatchingShowAllProductWithRoleResponse.builder()
+				.role(user.getRole().getValue())
+				.products(responses)
+				.build());
 	}
 	/**
 	 * MatchingKeepRequest 객체를 기반으로 Place와 Product를 매칭하여 Matching 엔티티를 생성하는 메서드
@@ -404,6 +413,30 @@ public class MatchingService {
 
 		matching.updatePlace(place);
 		return baseResponseService.getSuccessResponse();
+	}
+
+	public BaseResponse<List<MatchingShowAllResponse>> getProductsByPlace(Long placeId, Long userId) {
+		// 사용자 찾기
+		User user = findUser(userId);
+		// Place 찾기
+		Place place = placeRepository.findById(placeId)
+			.orElseThrow(() -> new CustomRuntimeException(PlaceException.PLACE_NOT_FOUND));
+
+		/*
+		 * Place와 관련된 매칭 찾기
+		 * 1. Status가 UNASSIGNED, REJECTED이고, Product의 User의 id가 userId와 같은 Matching들을 가져온다.
+		 * 2. 선택한 Place의 Category와 Matching들의 Category들을 비교해서, Place의 Category보다 작은 Matching들을 가져온다.
+		 */
+		List<Matching> matchings = matchingRepository.findMatchingsWithProductByStatus(userId);
+
+		// Place의 카테고리 value보다 작거나 같은 Product들만 필터링
+		List<MatchingShowAllResponse> responses = matchings.stream()
+			.filter(matching -> matching.getProduct().getCategory().getValue() <= place.getCategory().getValue())
+			.map(matchingAssembler::toMatchingShowAllResponse)
+			.collect(Collectors.toList());
+
+		// 필터링된 매칭 리스트를 반환
+		return baseResponseService.getSuccessResponse(responses);
 	}
 
 }

--- a/src/main/java/com/sharespace/sharespace_server/product/service/ProductService.java
+++ b/src/main/java/com/sharespace/sharespace_server/product/service/ProductService.java
@@ -46,7 +46,6 @@ public class ProductService {
                 .build();
         productRepository.save(product);
 
-        System.out.println(product.getId());
         List<String> imagesUrl = s3ImageUpload.uploadImages(request.getImageUrl(), "product/" + product.getId());
         product.setImageUrl(String.join(",", imagesUrl));
 

--- a/src/main/java/com/sharespace/sharespace_server/user/controller/UserController.java
+++ b/src/main/java/com/sharespace/sharespace_server/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.sharespace.sharespace_server.user.dto.UserEmailValidateRequest;
 import com.sharespace.sharespace_server.user.dto.UserGetIdResponse;
 import com.sharespace.sharespace_server.user.dto.UserGetInfoResponse;
 import com.sharespace.sharespace_server.user.dto.UserRegisterRequest;
+import com.sharespace.sharespace_server.user.dto.UserRegisterResponse;
 import com.sharespace.sharespace_server.user.dto.UserUpdateRequest;
 import com.sharespace.sharespace_server.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,7 +23,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/register")
-    public BaseResponse<Long> register(@Valid @RequestBody UserRegisterRequest request) {
+    public BaseResponse<UserRegisterResponse> register(@Valid @RequestBody UserRegisterRequest request) {
         return userService.register(request);
     }
 

--- a/src/main/java/com/sharespace/sharespace_server/user/dto/UserEmailValidateRequest.java
+++ b/src/main/java/com/sharespace/sharespace_server/user/dto/UserEmailValidateRequest.java
@@ -12,9 +12,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class UserEmailValidateRequest {
 
-    @NotNull
+    @NotNull(message = "userId는 null이 되어선 안 됩니다.")
     private Long userId;
 
-    @NotNull
     private Integer validationNumber;
 }

--- a/src/main/java/com/sharespace/sharespace_server/user/dto/UserRegisterResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/user/dto/UserRegisterResponse.java
@@ -1,0 +1,12 @@
+package com.sharespace.sharespace_server.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserRegisterResponse {
+	private Long userId;
+}

--- a/src/main/java/com/sharespace/sharespace_server/user/service/UserService.java
+++ b/src/main/java/com/sharespace/sharespace_server/user/service/UserService.java
@@ -15,6 +15,7 @@ import com.sharespace.sharespace_server.user.dto.UserEmailValidateRequest;
 import com.sharespace.sharespace_server.user.dto.UserGetIdResponse;
 import com.sharespace.sharespace_server.user.dto.UserGetInfoResponse;
 import com.sharespace.sharespace_server.user.dto.UserRegisterRequest;
+import com.sharespace.sharespace_server.user.dto.UserRegisterResponse;
 import com.sharespace.sharespace_server.user.dto.UserUpdateRequest;
 import com.sharespace.sharespace_server.user.entity.User;
 import com.sharespace.sharespace_server.user.repository.UserRepository;
@@ -54,7 +55,7 @@ public class UserService {
 
 
     @Transactional
-    public BaseResponse<Long> register(UserRegisterRequest request) {
+    public BaseResponse<UserRegisterResponse> register(UserRegisterRequest request) {
 
         // 이메일 중복 검사 메소드 호출
         emailDuplicate(request.getEmail());
@@ -87,7 +88,10 @@ public class UserService {
         // 이메일 전송 메소드 호출
         sendEmail(request.getEmail());
 
-        return baseResponseService.getSuccessResponse(user.getId());
+        return baseResponseService.getSuccessResponse(UserRegisterResponse.
+            builder()
+            .userId(user.getId())
+            .build());
     }
 
     // 이메일 인증여부 업데이트
@@ -96,6 +100,7 @@ public class UserService {
 
         User user = userRepository.findById(request.getUserId()).orElseThrow(() -> new CustomRuntimeException(UserException.MEMBER_NOT_FOUND));
         // 이메일 인증 확인 메소드 호출
+        System.out.println(request.getValidationNumber());
         verifyCode(user.getEmail(), request.getValidationNumber());
 
         user.setEmailValidated(true);


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 작업

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

#108 

## 반영 브랜치를 적어주세요.

branch : `Chore/108-FE와-API-연결`

## 상세 내용을 적어주세요.

1. 신규 API 추가 (`/matching/by-place?placeId={}`)
- `MatchingController.java`의 `getProductsByPlace()` 메서드, `MatchingService.java`의 `getProductsByPlace()` 메서드
- `placeId`에 따라 `Matching` 테이블에 등록된 `Product`를 조회하는 API
- 장소를 선택하고, 해당 장소의 `Category`에 맞는 유저의 `Product`를 조회하는 API
- 해당 API에서 필요한 쿼리 메서드인 `MatchingRepository.java`에 `findMatchingWithProudctByStatus()` 추가

2. `/matching`, `/matching?matchingId={}` API 변경
- 기존에 Response로 `List<MatchingShowAllResponse>>` 타입을 사용하고 있었는데, 이를 `MatchingShowAllProductWithRoleResponse`로 변경
- 이는 기존의 데이터에 해당 유저의 권한 (`String`)을 반환하기 위함, 자세한 것은 변동된 API 명세 문서 참고

3. 회원가입 프로세스에 사용되는 API 관련 변경
- `UserEmailValidateRequest.java` : validationNumber의 NotNull 제약조건 제거, `userId`의 NotNull 제약조건에 message문 변경
  - validationNumber의 NotNull 제약 조건은 추후에 추가해도 좋을 것 같음
- 회원가입 Response DTO 변경 : Long -> UserRegisterResponse.java
  - 기존에 data : 8과 같은 형태로 넘어오던 Response를 data : { "userId : 8" }과 같은 형태로 넘어오게끔 Response DTO 사용하여 응답 데이터 직렬화

4. 그 외 자잘한 코드 리팩토링