### PR TITLE
API 연결 과정 중에 있었던 문제 일부 수정

### DIFF
--- a/src/main/java/com/sharespace/sharespace_server/global/exception/error/MatchingException.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/exception/error/MatchingException.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum MatchingException implements CustomException {
-	MATCHING_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 매칭입니다."),
+	MATCHING_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 매칭이거나 물품이 누락되었습니다."),
 	CATEGORY_NOT_MATCHED(HttpStatus.BAD_REQUEST, "Category에 알맞은 물품을 보관 요청해야합니다."),
 	MATCHING_PRODUCT_NOT_IN_USER(HttpStatus.BAD_REQUEST, "해당 매칭의 Product를 가지고 있지 않는 유저입니다."),
 	MATCHING_PLACE_NOT_IN_USER(HttpStatus.BAD_REQUEST, "해당 매칭의 Place를 가지고 있지 않는 유저입니다."),

--- a/src/main/java/com/sharespace/sharespace_server/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/filter/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
 
-    private final String[] whiteListUris = new String[] {"/login", "/user/login", "/user/register", "/user/checkLogin"};
+    private final String[] whiteListUris = new String[] {"/login", "/user/login", "/user/register", "/user/checkLogin", "/token/reissue", "/logout"};
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/com/sharespace/sharespace_server/matching/dto/request/MatchingKeepRequest.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/dto/request/MatchingKeepRequest.java
@@ -10,7 +10,5 @@ public class MatchingKeepRequest {
 	@NotNull
 	private Long matchingId;
 	@NotNull
-	private Long productId;
-	@NotNull
 	private Long placeId;
 }

--- a/src/main/java/com/sharespace/sharespace_server/matching/dto/response/MatchingShowAllResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/dto/response/MatchingShowAllResponse.java
@@ -16,5 +16,4 @@ public class MatchingShowAllResponse {
 	private List<String> imageUrl; // product 이미지
 	private Status status;
 	private Integer distance;
-	private String role;
 }

--- a/src/main/java/com/sharespace/sharespace_server/matching/service/MatchingService.java
+++ b/src/main/java/com/sharespace/sharespace_server/matching/service/MatchingService.java
@@ -121,18 +121,19 @@ public class MatchingService {
 		// Place와 Product를 찾고, 유효성 검증
 		Place place = placeRepository.findById(request.getPlaceId())
 			.orElseThrow(() -> new CustomRuntimeException(PlaceException.PLACE_NOT_FOUND));
-		Product product = productRepository.findById(request.getProductId())
-			.orElseThrow(() -> new CustomRuntimeException(ProductException.PRODUCT_NOT_FOUND));
-
-		// productId와 placeId가 이미 존재하는 매칭일 경우 예외 던짐
-		if (matchingRepository.findMatchingByProductIdAndPlaceId(product.getId(), place.getId()).isPresent()) {
-			throw new CustomRuntimeException(MatchingException.ALREADY_REQUESTED_PRODUCT_TO_SAME_PLACE);
-		}
-
+		// Matching을 찾는 것은 곧 Product에 대한 유효성 검증이기도 함
 		Matching matching = matchingRepository.findById(request.getMatchingId())
 			.orElseThrow(() -> new CustomRuntimeException(MatchingException.MATCHING_NOT_FOUND));
 
+
+		// productId와 placeId가 이미 존재하는 매칭일 경우 예외 던짐 => 무한 매칭 방지
+		if (matchingRepository.findMatchingByProductIdAndPlaceId(matching.getProduct().getId(), place.getId()).isPresent()) {
+			throw new CustomRuntimeException(MatchingException.ALREADY_REQUESTED_PRODUCT_TO_SAME_PLACE);
+		}
+		
+
 		// Product와 Place에서 Category와 Period에 대해 유효성 검증 수행
+		Product product = matching.getProduct();
 		product.validateCategoryForPlace(place);
 		product.validatePeriodForPlace(place);
 		product.validateProductOwnershipForUser(user);


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [x] 기타 작업

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

#141 

## 반영 브랜치를 적어주세요.

branch : `Fix/141-API-문제-해결`

## 상세 내용을 적어주세요.
- 보관요청 (`/matching/keep`) => Request Body에 `productId` 제거
  - 관련된 서비스 계층의 비즈니스 로직 일부 수정
  - product의 유효성 검증을 Matching으로 옮김
 - 상태 필터링 API의 경우, 각 product의 항목에 한해 유저의 role이 넘어왔던 점 수정 (Response DTO의 role 필드를 제거)
- Matching이 존재하지 않는다는 것은 곧 Product가 존재하지 않는다는 것일 수도 있기 때문에, 메시지를 변경하였습니다.
- 쿠키에 담길 Key와 Value가 뒤바뀐 사항 수정
- 기존에 Token의 클레임을 기반으로 유저를 찾던 로직에서 Token을 직접 Repository에서 꺼내오는 것으로 변경
  - Refresh Token의 클레임에는 userId가 없기 때문에 이 방식을 채택해야 함