### PR TITLE
인가처리 방식 수정

### DIFF
--- a/src/main/java/com/sharespace/sharespace_server/global/exception/error/JwtException.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/exception/error/JwtException.java
@@ -14,7 +14,7 @@ public enum JwtException implements CustomException {
     // ILLEGAL_ARGUMENT_EXCEPTION(HttpStatus.UNAUTHORIZED, "잘못된 값이 들어왔습니다."),
     REFRESH_TOKEN_NOT_FOUND_EXCEPTION(HttpStatus.BAD_REQUEST, "DB에 Refresh token이 존재하지 않습니다."),
     BLACKLISTED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "블랙리스트에 등록된 토큰입니다."),
-    MISSING_HEADER_TOKEN(HttpStatus.UNAUTHORIZED, "Header에 토큰이 존재하지 않습니다.");
+    MISSING_COOKIE_TOKEN(HttpStatus.UNAUTHORIZED, "쿠키 내에 토큰이 존재하지 않습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/com/sharespace/sharespace_server/global/filter/LoginFilter.java
+++ b/src/main/java/com/sharespace/sharespace_server/global/filter/LoginFilter.java
@@ -144,7 +144,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     // 로그인 성공시 JWT를 쿠키에 저장한다.
     public void addJwtToCookie(HttpServletResponse response, String jwtToken, String cookieName, int maxAge) {
         Cookie cookie = new Cookie(cookieName, jwtToken);
-        cookie.setHttpOnly(false);
+        cookie.setHttpOnly(true);
         cookie.setSecure(false);
         cookie.setPath("/");
         cookie.setMaxAge(maxAge); // 2시간


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 작업

## 반영 브랜치를 적어주세요.

branch : Feat/UserLoginRefactor

## 상세 내용을 적어주세요.
- jwt인증필터 내 인가처리 방식을 인증헤더 토큰추출에서 서버의 브라우저 쿠키 직접 접근 방식으로 수정
- 쿠키 내에 토큰이 존재하지 않을시 예외처리 추가
- 로그인 필터단 토큰추가시 httponly 플래그 활성화