### PR TITLE
쪽지 읽음 처리 및 안읽은 쪽지 개수 반환 API 제작

### DIFF
--- a/src/main/java/com/sharespace/sharespace_server/note/controller/NoteController.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/controller/NoteController.java
@@ -19,6 +19,7 @@ import com.sharespace.sharespace_server.note.dto.NoteDetailResponse;
 import com.sharespace.sharespace_server.note.dto.NoteRequest;
 import com.sharespace.sharespace_server.note.dto.NoteResponse;
 import com.sharespace.sharespace_server.note.dto.NoteSenderListResponse;
+import com.sharespace.sharespace_server.note.dto.NoteUnreadCountResponse;
 import com.sharespace.sharespace_server.note.service.NoteService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -76,5 +77,13 @@ public class NoteController {
 	@CheckPermission(roles = {"ROLE_GUEST", "ROLE_HOST"})
 	public BaseResponse<Void> getUnreadNote(@PathVariable Long noteId) {
 		return noteService.markNoteAsRead(noteId);
+	}
+	
+	// task: 안읽은 쪽지 개수 조회
+	@GetMapping("/unreadNote")
+	@CheckPermission(roles = {"ROLE_GUEST", "ROLE_HOST"})
+	public BaseResponse<NoteUnreadCountResponse> markNoteAsRead(HttpServletRequest httpRequest) {
+		Long userId = RequestParser.extractUserId(httpRequest);
+		return noteService.getUnreadNote(userId);
 	}
 }

--- a/src/main/java/com/sharespace/sharespace_server/note/controller/NoteController.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/controller/NoteController.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -67,5 +69,12 @@ public class NoteController {
 	public BaseResponse<List<NoteSenderListResponse>> getSenderList(HttpServletRequest httpRequest) {
 		Long userId = RequestParser.extractUserId(httpRequest);
 		return noteService.getSenderList(userId);
+	}
+
+	// task: 쪽지 읽음 처리
+	@PatchMapping("/{noteId}/read")
+	@CheckPermission(roles = {"ROLE_GUEST", "ROLE_HOST"})
+	public BaseResponse<Void> getUnreadNote(@PathVariable Long noteId) {
+		return noteService.markNoteAsRead(noteId);
 	}
 }

--- a/src/main/java/com/sharespace/sharespace_server/note/dto/NoteResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/dto/NoteResponse.java
@@ -16,6 +16,7 @@ public class NoteResponse {
 	private String title;
 	private String content;
 	private String sender;
+	private boolean isRead;
 
 	public static NoteResponse toNoteResponse(Note note) {
 		return NoteResponse.builder()
@@ -23,6 +24,7 @@ public class NoteResponse {
 			.title(note.getTitle())
 			.content(note.getContent())
 			.sender(note.getSender().getNickName())
+			.isRead(note.isRead())
 			.build();
 	}
 }

--- a/src/main/java/com/sharespace/sharespace_server/note/dto/NoteUnreadCountResponse.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/dto/NoteUnreadCountResponse.java
@@ -1,0 +1,12 @@
+package com.sharespace.sharespace_server.note.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NoteUnreadCountResponse {
+	private final int unreadCount;
+
+	public NoteUnreadCountResponse(int unreadCount) {
+		this.unreadCount = unreadCount;
+	}
+}

--- a/src/main/java/com/sharespace/sharespace_server/note/entity/Note.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/entity/Note.java
@@ -45,6 +45,9 @@ public class Note {
 	@Column(name = "send_at", nullable = false)
 	public LocalDateTime send_at;
 
+	@Column(name = "is_read", nullable = false)
+	public boolean isRead;
+
 	@Builder
 	public Note(User sender, User receiver, String title, String content, LocalDateTime send_at) {
 		this.sender = sender;

--- a/src/main/java/com/sharespace/sharespace_server/note/repository/NoteRepository.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/repository/NoteRepository.java
@@ -3,6 +3,7 @@ package com.sharespace.sharespace_server.note.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.sharespace.sharespace_server.note.entity.Note;
@@ -10,4 +11,7 @@ import com.sharespace.sharespace_server.note.entity.Note;
 @Repository
 public interface NoteRepository extends JpaRepository<Note, Long> {
 	List<Note> findAllByReceiverId(Long userId);
+
+	@Query("SELECT COUNT(*) FROM Note n Where n.isRead = false AND n.receiver.id = :userId")
+	int findCountUnreadNotesByReceiverId(Long userId);
 }

--- a/src/main/java/com/sharespace/sharespace_server/note/service/NoteService.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/service/NoteService.java
@@ -131,6 +131,20 @@ public class NoteService {
 	}
 
 	/**
+	 * 쪽지 읽음 처리
+	 *
+	 * @param noteId 조회하고자 하는 쪽지 고유 ID
+	 * @return 성공 여부 반환
+	 * @Author thereisname
+	 */
+	@Transactional
+	public BaseResponse<Void> markNoteAsRead(Long noteId) {
+		Note note = findNoteById(noteId);
+		note.setRead(true);
+		return baseResponseService.getSuccessResponse();
+	}
+
+	/**
 	 * 로그인 사용자가 쪽지를 보낼 수 있는 발신자 리스트 조회
 	 * <p>
 	 *     사용자의 역할(Role)에 따라 매칭된 사용자 리스트를 조회하여, 쪽지를 보낼 수 있는 발신자 리스트를 반환

--- a/src/main/java/com/sharespace/sharespace_server/note/service/NoteService.java
+++ b/src/main/java/com/sharespace/sharespace_server/note/service/NoteService.java
@@ -20,6 +20,7 @@ import com.sharespace.sharespace_server.note.dto.NoteDetailResponse;
 import com.sharespace.sharespace_server.note.dto.NoteRequest;
 import com.sharespace.sharespace_server.note.dto.NoteResponse;
 import com.sharespace.sharespace_server.note.dto.NoteSenderListResponse;
+import com.sharespace.sharespace_server.note.dto.NoteUnreadCountResponse;
 import com.sharespace.sharespace_server.note.entity.Note;
 import com.sharespace.sharespace_server.note.repository.NoteRepository;
 import com.sharespace.sharespace_server.notification.service.NotificationService;
@@ -160,6 +161,23 @@ public class NoteService {
 		List<NoteSenderListResponse> users = getUsersByRole(user);
 
 		return baseResponseService.getSuccessResponse(users);
+	}
+
+	/**
+	 * 받은 쪽지 중 안읽은 쪽지 개수 조회
+	 *
+	 * <p>Note 엔티티 컬럼 중 사용자가 받은 쪽지 중 is_read가 false인 값들의 개수를 조회</p>
+	 *
+	 * @param userId 현재 로그인한 사용자의 고유 ID
+	 * @return 읽지 않은 쪽지 개수 반환
+	 * @Author thereisname
+	 */
+	@Transactional
+	public BaseResponse<NoteUnreadCountResponse> getUnreadNote(Long userId) {
+		int unreadCount = noteRepository.findCountUnreadNotesByReceiverId(userId);
+		return baseResponseService.getSuccessResponse(
+			new NoteUnreadCountResponse(unreadCount)
+		);
 	}
 
 	// task: 사용자가 존재하는지 검증하고 사용자 객체 반환


### PR DESCRIPTION
# Pull Request

## 해결한 이슈의 타입을 선택해주세요.

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 작업

## 해결한 이슈의 번호를 적어주세요. (# 이후에 숫자를 입력하면 이슈가 종료됩니다.)

close #156 

## 반영 브랜치를 적어주세요.

branch : Feat/156-Note-읽음처리

## 상세 내용을 적어주세요.
- 쪽지 읽음을 확인하기 위한 컬럼 추가. Note 테이블 내 `is_read` 컬럼 추가
- is_read를 true로 변경하는API 제작 (쪽지 읽음으로 변경하는 API)
- 사용자가 수신한 쪽지 중 읽지 않은 쪽지 개수를 response로 반환하는 API 제작
